### PR TITLE
function primaryExistsByFields() added

### DIFF
--- a/vendor/srag/dic/src/Database/DatabaseDetector.php
+++ b/vendor/srag/dic/src/Database/DatabaseDetector.php
@@ -216,4 +216,11 @@ class DatabaseDetector extends AbstractILIASDatabaseDetector
             return $primary_key_value;
         }
     }
+
+
+    public function primaryExistsByFields(string $table_name, array $fields): bool
+    {
+        // TODO: Implement primaryExistsByFields() method.
+        return false;
+    }
 }


### PR DESCRIPTION
solves:

Whoops\Exception\ErrorException thrown with message "Class srag\DIC\OpencastPageComponent\Database\DatabaseDetector contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (ilDBInterface::primaryExistsByFields)"