### PR TITLE
Fix for incompatibility with Opencast Plugin v5.6.0

### DIFF
--- a/classes/class.ilOpencastPageComponentPluginGUI.php
+++ b/classes/class.ilOpencastPageComponentPluginGUI.php
@@ -75,7 +75,7 @@ class ilOpencastPageComponentPluginGUI extends ilPageComponentPluginGUI
      */
     public function __construct()
     {
-        global $DIC;
+        global $DIC, $opencastContainer;
         $this->dic = $DIC;
         $this->opencast_dic = OpencastDIC::getInstance();
         $this->opencast_dic->overwriteService('upload_handler',
@@ -87,7 +87,13 @@ class ilOpencastPageComponentPluginGUI extends ilPageComponentPluginGUI
                     [ilObjPluginDispatchGUI::class, ocpcRouterGUI::class, xoctFileUploadHandler::class], 'info'),
                 $this->dic->ctrl()->getLinkTargetByClass(
                     [ilObjPluginDispatchGUI::class, ocpcRouterGUI::class, xoctFileUploadHandler::class], 'remove')));
-        $this->event_repository = $this->opencast_dic->event_repository();
+
+        if (method_exists($this->opencast_dic, 'event_repository')) {
+            $this->event_repository = $this->opencast_dic->event_repository();
+        } else if ($opencastContainer && isset($opencastContainer[EventAPIRepository::class])) {
+            $this->event_repository = $opencastContainer[EventAPIRepository::class];
+        }
+
         PluginConfig::setApiSettings();
         parent::__construct();
     }

--- a/src/Table/VideoSearchTableGUI.php
+++ b/src/Table/VideoSearchTableGUI.php
@@ -7,6 +7,7 @@ use srag\Plugins\Opencast\Model\Event\Event;
 use srag\Plugins\Opencast\Model\Event\EventAPIRepository;
 use srag\Plugins\Opencast\Model\Metadata\Definition\MDFieldDefinition;
 use srag\Plugins\Opencast\Model\Series\SeriesRepository;
+use srag\Plugins\Opencast\Model\Series\SeriesAPIRepository;
 use srag\Plugins\Opencast\Model\User\xoctUser;
 use srag\Plugins\Opencast\DI\OpencastDIC;
 
@@ -58,12 +59,24 @@ class VideoSearchTableGUI extends TableGUI
                                 Container $dic,
                                 string $command_url)
     {
+        global $opencastContainer;
         $this->dic = $dic;
         $this->command_url = $command_url;
         $this->opencast_plugin = ilOpenCastPlugin::getInstance();
         $opencast_dic = OpencastDIC::getInstance();
-        $this->event_repository = $opencast_dic->event_repository();
-        $this->series_repository = $opencast_dic->series_repository();
+
+        if (method_exists($opencast_dic, 'event_repository')) {
+            $this->event_repository = $opencast_dic->event_repository();
+        } else if (!empty($opencastContainer)) {
+            $this->event_repository = $opencastContainer[EventAPIRepository::class];
+        }
+
+        if (method_exists($opencast_dic, 'series_repository')) {
+            $this->series_repository = $opencast_dic->series_repository();
+        } else if (!empty($opencastContainer)) {
+            $this->series_repository = $opencastContainer->get(SeriesAPIRepository::class);
+        }
+
         $this->initId();    // this is necessary so the offset and order can be determined
         $this->setExternalSegmentation(true);
         $this->setExternalSorting(true);


### PR DESCRIPTION
This PR fixes #16 

#### How it works
To access to `event_repository` as well as `series_repository`, older version of Opencast Plugin provides these two property directly via `OpencastDIC` class, however, due to the latest changes and refactoring every important property of Opencast Plugin is provided via `OpencastContainer` accessible only with the ease of calling `global $opencastContainer`

#### Important to notice
In order to be backward compatibility, namely with older Opencast Plugin versions < 5.6.0. The fix is designed to handle both scenarios.