### PR TITLE
Display Series title & id

### DIFF
--- a/src/Table/VideoSearchTableGUI.php
+++ b/src/Table/VideoSearchTableGUI.php
@@ -138,8 +138,10 @@ class VideoSearchTableGUI extends TableGUI
             case 'series':
                 /** @var Event $object */
                 $object = $row['object'];
-
-                return $object->getSeries();
+                $series_object = $this->series_repository->find($object->getSeries());
+                $series_title = $series_object->getMetadata()->getField(MDFieldDefinition::F_TITLE)->getValue()
+                    . ' (...' . substr($series_object->getIdentifier(), -4, 4) . ')';
+                return $series_title;
             case 'start':
                 return date('d.m.Y H:i', $row['start_unix']);
             case 'location':


### PR DESCRIPTION
This PR fixes #9 

### Description
please refer to the related issue.

### How it works
In Video Search Table (`VideoSearchTableGUI`), instead of showing only the series id, we now first get the series object based on the event series id, and then extract the series title via `series_repository`.

### Important to know
To test this PR it is necessary to have PR #17 patched first (in case you are using Opencast Series Object Plugin v5.6.0)!