### PR TITLE
[FIX] Remove ineffective 'Default width'/'Default height' config options #44

### DIFF
--- a/classes/class.ilOpencastPageComponentPluginGUI.php
+++ b/classes/class.ilOpencastPageComponentPluginGUI.php
@@ -334,14 +334,8 @@ class ilOpencastPageComponentPluginGUI extends ilPageComponentPluginGUI
 
         $properties = [
             self::PROP_EVENT_ID => $event_id,
-            self::PROP_HEIGHT => $event_ratio?->getHeight() ?? max(
-                (int) Config::getField(Config::KEY_DEFAULT_HEIGHT),
-                Config::DEFAULT_HEIGHT
-            ),
-            self::PROP_WIDTH => $event_ratio?->getWidth() ?? max(
-                (int) Config::getField(Config::KEY_DEFAULT_WIDTH),
-                Config::DEFAULT_WIDTH
-            ),
+            self::PROP_HEIGHT => $event_ratio?->getHeight() ?? Config::DEFAULT_HEIGHT,
+            self::PROP_WIDTH => $event_ratio?->getWidth() ?? Config::DEFAULT_WIDTH,
             self::PROP_POSITION => self::POSITION_LEFT,
             self::PROP_RESPONSIVE => true,
             self::PROP_AS_LINK => (bool) Config::getField(Config::KEY_DEFAULT_AS_LINK),

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -6,8 +6,6 @@ form_title#:#Videoeigenschaften Bearbeiten
 width#:#Breite
 height#:#Höhe
 height_width#:#Maximale Breite / Höhe in Pixel
-config_default_width#:#Standard-Breite
-config_default_height#:#Standard-Höhe
 config_default_as_link#:#Standardmässig "Vorschaubild verlinkt auf Video"
 msg_failed_loading_events#:#Beim Laden der Events ist ein Fehler aufgetreten: %s
 msg_created#:#Upload abgeschlossen. Hinweis: Es kann einige Minuten dauern, bis das Video verarbeitet wurde und in der Liste unten erscheint.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -6,8 +6,6 @@ form_title#:#Edit Video Properties
 width#:#Width
 height#:#Height
 height_width#:#Max. width / height in pixels
-config_default_width#:#Default width
-config_default_height#:#Default height
 config_default_as_link#:#Default ‘Preview image links to video’
 msg_failed_loading_events#:#An error occurred while loading events: %s
 msg_created#:#Upload complete. Note: It may take a few minutes for the video to be processed and appear in the list below.

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -24,9 +24,8 @@ namespace srag\Plugins\OpencastPageComponent\Config;
 class Config
 {
     public const TABLE_NAME = "copg_pgcp_ocpc_config";
-    public const KEY_DEFAULT_WIDTH = "default_width";
+    // Fallback dimensions used only when an event's own publication dimensions cannot be determined.
     public const DEFAULT_WIDTH = 640;
-    public const KEY_DEFAULT_HEIGHT = "default_height";
     public const DEFAULT_HEIGHT = 480;
     public const KEY_DEFAULT_AS_LINK = "default_as_link";
 

--- a/src/Config/ConfigForm.php
+++ b/src/Config/ConfigForm.php
@@ -81,35 +81,6 @@ class ConfigForm
         $ff = $this->ui_factory->input()->field();
 
         $inputs[] = $ff
-            ->numeric(
-                $this->getLocaleString(Config::KEY_DEFAULT_WIDTH)
-                // , $this->getLocaleString(Config::KEY_DEFAULT_WIDTH . '_info')
-            )
-            ->withValue(
-                (int) $this->config_repository->get(Config::KEY_DEFAULT_WIDTH, 640)->getValue()
-            )
-            ->withRequired(true)
-            ->withAdditionalTransformation(
-                $this->refinery->custom()->transformation(fn($value): Config => $this->config_repository->store(
-                    new Config(Config::KEY_DEFAULT_WIDTH, (int) $value)
-                ))
-            );
-
-        $inputs[] = $ff
-            ->numeric(
-                $this->getLocaleString(Config::KEY_DEFAULT_HEIGHT)
-                // , $this->getLocaleString(Config::KEY_DEFAULT_HEIGHT . '_info')
-            )->withValue(
-                (int) $this->config_repository->get(Config::KEY_DEFAULT_HEIGHT, 480)->getValue()
-            )
-            ->withRequired(true)
-            ->withAdditionalTransformation(
-                $this->refinery->custom()->transformation(fn($value): Config => $this->config_repository->store(
-                    new Config(Config::KEY_DEFAULT_HEIGHT, (int) $value)
-                ))
-            );
-
-        $inputs[] = $ff
             ->checkbox(
                 $this->getLocaleString(Config::KEY_DEFAULT_AS_LINK)
                 // , $this->getLocaleString(Config::KEY_DEFAULT_AS_LINK . '_info')


### PR DESCRIPTION
Removes the "Default width" and "Default height" configuration options, which had no effect (per meeting decision). Fixes #44.